### PR TITLE
feature/mqtt (initial pub cov only)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ schedule==0.6.0
 psycopg2-binary
 gunicorn
 influxdb
+paho-mqtt

--- a/settings/config.example.ini
+++ b/settings/config.example.ini
@@ -9,4 +9,6 @@ qos = 1
 retain = false
 # publish_value publishes the value only topic ( .../value ) ( .../data still gets published)
 publish_value = false
+attempt_reconnect_on_unavailable = true
+attempt_reconnect_secs = 5
 debug = false

--- a/settings/config.example.ini
+++ b/settings/config.example.ini
@@ -1,0 +1,12 @@
+[settings]
+enable_mqtt = true
+
+[mqtt]
+host = 0.0.0.0
+port = 1883
+keepalive = 60
+qos = 1
+retain = false
+# publish_value publishes the value only topic ( .../value ) ( .../data still gets published)
+publish_value = false
+debug = false

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -11,6 +11,7 @@ CORS(app)
 
 # TMP CONFIGS
 db_pg = False
+enable_mqtt = True
 enable_histories = True
 enable_tcp = False
 enable_rtu = True
@@ -31,6 +32,7 @@ app.config['SQLALCHEMY_ECHO'] = False  # for print the sql query
 db = SQLAlchemy(app)
 
 # Other Services
+from src.services.mqtt_client.mqtt_client import MqttClient
 from src.services.histories.history_local import HistoryLocal
 from src.services.histories.point_store_history_cleaner import PointStoreHistoryCleaner
 # Source Drivers
@@ -49,6 +51,12 @@ if not not os.environ.get("WERKZEUG_RUN_MAIN"):
     if enable_histories:
         histories_thread = Thread(target=HistoryLocal.get_instance().sync_interval)
         histories_thread.start()
+
+    # if config.getboolean('settings', 'enable_mqtt'):
+    if enable_mqtt:
+    # mqtt_thread = Thread(target=MqttClient.get_instance().start)
+        mqtt_thread = Thread(target=MqttClient.get_instance().start, args=('localhost', 1883))
+        mqtt_thread.start()
 
     # Network.get_instance().start()
 

--- a/src/models/model_base.py
+++ b/src/models/model_base.py
@@ -1,3 +1,4 @@
+from sqlalchemy.orm import validates
 from src import db
 
 
@@ -20,3 +21,9 @@ class ModelBase(db.Model):
         if hasattr(self, 'updated_on'):
             self.updated_on = db.func.now()
         db.session.commit()
+
+    @validates('name')
+    def validate_name(self, _, name):
+        if '/' in name:
+            raise ValueError('name cannot contain forward slash (/)')
+        return name

--- a/src/models/point/model_point.py
+++ b/src/models/point/model_point.py
@@ -39,6 +39,5 @@ class PointModel(ModelBase):
     @validates('history_interval')
     def validate_history_interval(self, _, value):
         if self.history_type == HistoryType.INTERVAL and value is not None and value < 1:
-            print('tRUE')
-            raise ValueError("This needs to be at least 1, default is 15 (in minutes)")
+            raise ValueError("history_interval needs to be at least 1, default is 15 (in minutes)")
         return value

--- a/src/services/histories/histories.py
+++ b/src/services/histories/histories.py
@@ -14,6 +14,7 @@ SERVICE_NAME_HISTORIES = 'histories'
 
 class Histories(EventServiceBase):
     service_name = SERVICE_NAME_HISTORIES
+    threaded = True
     _push_period_minutes = 1
 
     _instance = None

--- a/src/services/histories/history_local.py
+++ b/src/services/histories/history_local.py
@@ -19,6 +19,7 @@ class HistoryLocal(EventServiceBase):
     """
     SYNC_PERIOD = 5
     service_name = SERVICE_NAME_HISTORIES_LOCAL
+    threaded = True
 
     _instance = None
     binding = None

--- a/src/services/mqtt_client/mqtt_client.py
+++ b/src/services/mqtt_client/mqtt_client.py
@@ -1,0 +1,148 @@
+import paho.mqtt.client as mqtt
+import json
+
+# from src.ini_config import config
+from src.services.event_service_base import EventServiceBase, Event, EventTypes
+from src.event_dispatcher import EventDispatcher
+from src.models.point.model_point import PointModel
+from src.models.point.model_point_store import PointStoreModel
+
+SERVICE_NAME_MQTT_CLIENT = 'mqtt'
+
+MQTT_TOPIC = 'rubix/points'
+MQTT_TOPIC_MIN = len(MQTT_TOPIC.split('/')) + 1
+MQTT_TOPIC_ALL = 'all'
+MQTT_TOPIC_DRIVER = 'driver'
+
+
+DEFAULT_host = 'localhost'
+DEFAULT_port = 1883
+DEFAULT_keepalive = 60
+DEFAULT_qos = 1
+DEFAULT_retain = False
+DEFAULT_publish_value = False
+DEFAULT_debug = False
+
+
+class MqttClient(EventServiceBase):
+    service_name = SERVICE_NAME_MQTT_CLIENT
+    threaded = False
+    __instance = None
+    __client = None
+    __keepalive = DEFAULT_keepalive
+    __qos = DEFAULT_qos
+    __retain = DEFAULT_retain
+    __publish_value = DEFAULT_publish_value
+    __debug = DEFAULT_debug
+
+    def __init__(self):
+        if MqttClient.__instance:
+            raise Exception("MqttClient class is a singleton class!")
+        else:
+            super().__init__()
+            self.supported_events[EventTypes.POINT_COV] = True
+            EventDispatcher.add_service(self)
+            # MqttClient.__keepalive = int(config.get('mqtt', 'keepalive', fallback=DEFAULT_keepalive))
+            # MqttClient.__qos = int(config.get('mqtt', 'qos', fallback=DEFAULT_qos))
+            # MqttClient.__retain = int(config.get('mqtt', 'retain', fallback=DEFAULT_retain))
+            # MqttClient.__publish_value = config.get('mqtt', 'publish_value', fallback=DEFAULT_publish_value)
+            # MqttClient.__debug = config.get('mqtt', 'debug', fallback=DEFAULT_debug)
+            MqttClient.__instance = self
+
+    @staticmethod
+    def get_instance():
+        if MqttClient.__instance is None:
+            MqttClient()
+        return MqttClient.__instance
+
+    @staticmethod
+    def start():
+        # TODO: remove when .ini added
+        raise Exception('.ini config not implemented')
+        # try:
+        # host = config.get('mqtt', 'host', fallback=DEFAULT_host)
+        # port = int(config.get('mqtt', 'port', fallback=DEFAULT_port))
+        #
+        # MqttClient.start(host, MqttClient.__port, MqttClient.__keepalive, MqttClient.__qos, MqttClient.__retain)
+        # except Exception as e:
+        #     print('MQTT Error', e)
+
+    @staticmethod
+    def start(host: str, port: int = DEFAULT_port, keepalive: int = DEFAULT_keepalive,
+              qos: int = DEFAULT_qos, retain: bool = DEFAULT_retain):
+        MqttClient.get_instance()
+        MqttClient.__client = mqtt.Client()
+        MqttClient.__qos = qos
+        MqttClient.__retain = retain
+        try:
+            MqttClient.__client.connect(host, port, keepalive)
+            MqttClient.__client.loop_forever()
+        except Exception as e:
+            print(f"Error {e}")
+
+    @staticmethod
+    def publish_cov(point: PointModel, point_store: PointStoreModel, device_uuid: str, network_uuid: str,
+                    source_driver: str):
+        if MqttClient.__client is None:
+            return
+        if point is None or point_store is None or device_uuid is None or network_uuid is None or source_driver is None:
+            raise Exception('Bad MQTT publish arguments')
+        topic = f'{MQTT_TOPIC}/{source_driver}/{network_uuid}/{device_uuid}/{point.uuid}/{point.name}'
+
+        payload = {
+            'value': point_store.value,
+            'value_array': point_store.value_array,
+            'fault': point_store.fault,
+            'fault_message': point_store.fault_message
+        }
+        if MqttClient.__debug:
+            print('MQTT PUB:', topic+'/data', payload)
+        MqttClient.__client.publish(topic+'/data', json.dumps(payload), MqttClient.__qos, MqttClient.__retain)
+        if MqttClient.__publish_value and not point_store.fault:
+            if MqttClient.__debug:
+                print('MQTT PUB', topic+'/value', point_store.value)
+            MqttClient.__client.publish(topic+'/value', point_store.value, MqttClient.__qos, MqttClient.__retain)
+
+    @staticmethod
+    def __on_connect(client, userdata, flags, reason_code, properties=None):
+        if reason_code > 0:
+            reasons = {
+                1: 'Connection refused - incorrect protocol version',
+                2: 'Connection refused - invalid client identifier',
+                3: 'Connection refused - server unavailable',
+                4: 'Connection refused - bad username or password',
+                5: 'Connection refused - not authorised'
+            }
+            reason = reasons.get(reason_code, 'unknown')
+            MqttClient.__client = None
+            raise Exception(f'MQTT Connection Failure: {reason}')
+        MqttClient.__client.subscribe(f'{MQTT_TOPIC}/#')
+
+    @staticmethod
+    def __on_message(client, userdata, message):
+        pass
+        # topic_split = message.topic.split('/')
+        # if len(topic_split) < MQTT_TOPIC_MIN:
+        #     return
+        # if topic_split[MQTT_TOPIC_MIN] == MQTT_TOPIC_ALL:
+        #     MqttClient.__handleAllMessage(topic_split, message)
+        # elif topic_split[MQTT_TOPIC_MIN] == MQTT_TOPIC_DRIVER:
+        #     MqttClient.__handleDriverMessage(topic_split, message)
+        # else:
+        #     return
+
+    @staticmethod
+    def __handleAllMessage(topic_split, message):
+        pass
+
+    @staticmethod
+    def __handleDriverMessage(topic_split, message):
+        pass
+
+    def _run_event(self, event: Event):
+        if event.event_type == EventTypes.POINT_COV:
+            if event.data is not None:
+                # TODO: maybe data checking or leave up to developer to speed up?
+                MqttClient.publish_cov(event.data.get('point'), event.data.get('point_store'),
+                                       event.data.get('device').uuid, event.data.get('network').uuid,
+                                       event.data.get('source_driver'))

--- a/src/source_drivers/modbus/services/modbus_functions/polling/poll.py
+++ b/src/source_drivers/modbus/services/modbus_functions/polling/poll.py
@@ -160,7 +160,14 @@ def poll_point(service: EventServiceBase, network: ModbusNetworkModel, device: M
 
     is_updated = point_store_new.update()
     if is_updated:
-        # EventDispatcher.dispatch_from_source(service, Event(EventTypes.POINT_COV))
+        EventDispatcher.dispatch_from_source(service, Event(EventTypes.POINT_COV, {
+            'point': point,
+            'point_store': point_store_new,
+            'device': device,
+            'network': network,
+            'source_driver': service.service_name
+        }))
+        # TODO: move this to history service local as the dispatch event will handle it
         if point.history_type == HistoryType.COV and network.history_enable and \
                 device.history_enable and point.history_enable:
             from src import HistoryLocal

--- a/src/source_drivers/modbus/services/rtu_polling.py
+++ b/src/source_drivers/modbus/services/rtu_polling.py
@@ -16,6 +16,7 @@ class RtuPolling(EventServiceBase):
     _instance = None
     _polling_period = 1
     service_name = SERVICE_NAME_MODBUS_RTU
+    threaded = True
     _count = 0
 
     @staticmethod

--- a/src/source_drivers/modbus/services/tcp_polling.py
+++ b/src/source_drivers/modbus/services/tcp_polling.py
@@ -14,6 +14,7 @@ class TcpPolling(EventServiceBase):
     _instance = None
     _polling_period = 1
     service_name = SERVICE_NAME_MODBUS_TCP
+    threaded = True
     _count = 0
 
     @staticmethod

--- a/tests/rest/req_modbus_rtu.py
+++ b/tests/rest/req_modbus_rtu.py
@@ -44,9 +44,14 @@ for n in range(1, networks+1):
     }
 
     response_n = requests.post(f'{network_url}', data=network_obj)
-    r_json = response_n.json()
-    network_uuid = r_json['uuid']
-    print('added network', r_json.get('name'), network_uuid)
+    network_uuid_uuid = None
+    if 200 <= response_n.status_code < 300:
+        r_json = response_n.json()
+        network_uuid = r_json['uuid']
+        print('added network', r_json.get('name'), network_uuid)
+    else:
+        print('failed to add network', network_obj.get('name'), response_n.reason)
+        continue
 
     for d in range(1, devices+1):
 
@@ -64,14 +69,19 @@ for n in range(1, networks+1):
         }
 
         response_d = requests.post(f'{devices_url}', data=devices_obj)
-        r_json = response_d.json()
-        device_uuid = r_json['uuid']
-        print('    added device', r_json.get('name'), device_uuid)
+        device_uuid = None
+        if 200 <= response_d.status_code < 300:
+            r_json = response_d.json()
+            device_uuid = r_json['uuid']
+            print('    added device', r_json.get('name'), device_uuid)
+        else:
+            print('    failed to add device', devices_obj.get('name'), response_d.reason)
+            continue
 
         for r in range(1, points+1):
             name = f'point_{r}'
             point_obj = {
-                "name": f'{name}/{d}/{r}',
+                "name": f'{name}\\{d}\\{r}',
                 "reg": r,
                 "reg_length": 2,
                 "type": reg_type,
@@ -85,5 +95,9 @@ for n in range(1, networks+1):
                 "device_uuid": device_uuid
             }
             response_p = requests.post(f'{points_url}', data=point_obj)
-            r_json = response_p.json()
-            print('        added point', r_json.get('name'), r_json.get('uuid'))
+            if 200 <= response_p.status_code < 300:
+                r_json = response_p.json()
+                print('        added point', r_json.get('name'), r_json.get('uuid'))
+            else:
+                print('        failed to add point', point_obj.get('name'), response_p.reason)
+                continue

--- a/tests/rest/req_simple.py
+++ b/tests/rest/req_simple.py
@@ -70,7 +70,7 @@ for d in devices:
     for i, r in enumerate(reg_address):
         name = reg_names[i]
         point_obj = {
-            "name": f'{name}/{d}/{r}',
+            "name": f'{name}\\{d}\\{r}',
             "reg": r,
             "reg_length": 2,
             "type": reg_type,


### PR DESCRIPTION
**Initial MQTT client**
publishes on COV
  
topic:
```
rubix/points/{source_driver}/{network_uuid}/{device_uuid}/{point.uuid}/{point.name}/data

[optional] (value only)
rubix/points/{source_driver}/{network_uuid}/{device_uuid}/{point.uuid}/{point.name}/value
```

example topics:
```
all points:
rubix/points/+/+/+/+/+/data

all modbus rtu points:
rubix/points/modbus_rtu/+/+/+/+/data

by point uuid:
rubix/points/+/+/+/example_point_uuid/+/data

by point name:
rubix/points/+/+/+/+/example_point_name/data
```
Other changes:
- `network`, `device`, `point` names can no longer contain forward slash (`/`)
- event services now have a `threaded` flag which dictates whether an event of the subscribing service will be run by the publishing service or added to the event queue or the subscribing service. This will probs be changed in future to be method independent
  
config support added but commented out for now