### PR TITLE
mqtt multiple clients

### DIFF
--- a/logging/logging.conf
+++ b/logging/logging.conf
@@ -43,7 +43,7 @@ qualname=modbus_debug_poll
 propagate=0
 
 [logger_source_driver_modbus]
-level=DEBUG
+level=INFO
 handlers=consoleHandler
 qualname=src.source_drivers.modbus
 propagate=0

--- a/logging/logging.conf
+++ b/logging/logging.conf
@@ -1,5 +1,5 @@
 [loggers]
-keys=root,werkzeug,pymodbus,modbus_debug,modbus_debug_poll,source_driver_modbus
+keys=root,werkzeug,mqtt,pymodbus,modbus_debug,modbus_debug_poll,source_driver_modbus
 # pymodbus logger limiting on INFO
 
 [handlers]
@@ -16,6 +16,12 @@ handlers=consoleHandler
 level=INFO
 handlers=consoleHandler
 qualname=werkzeug
+propagate=0
+
+[logger_mqtt]
+level=INFO
+handlers=consoleHandler
+qualname=src.services.mqtt_client
 propagate=0
 
 [logger_pymodbus]
@@ -37,7 +43,7 @@ qualname=modbus_debug_poll
 propagate=0
 
 [logger_source_driver_modbus]
-level=INFO
+level=DEBUG
 handlers=consoleHandler
 qualname=src.source_drivers.modbus
 propagate=0

--- a/settings/config.example.ini
+++ b/settings/config.example.ini
@@ -2,11 +2,11 @@
 enable_mqtt = true
 enable_tcp = false
 enable_rtu = true
-enable_histories = true
-enable_cleaner = true
+enable_histories = false
+enable_cleaner = false
 enable_history_sync = false
 
-[mqtt]
+[mqtt_local]
 host = 0.0.0.0
 port = 1883
 keepalive = 60
@@ -16,7 +16,6 @@ retain = true
 publish_value = false
 attempt_reconnect_on_unavailable = true
 attempt_reconnect_secs = 5
-debug = false
 
 [influx_db]
 host = 0.0.0.0

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -4,7 +4,7 @@ import os
 from flask import Flask
 from flask_cors import CORS
 from flask_sqlalchemy import SQLAlchemy
-from sqlalchemy.engine import Engine
+from sqlalchemy.engine.base import Engine
 from sqlalchemy import event
 
 from src.event_dispatcher import EventDispatcher

--- a/src/ini_config.py
+++ b/src/ini_config.py
@@ -18,16 +18,6 @@ settings__enable_histories = config.getboolean('settings', 'enable_histories', f
 settings__enable_cleaner = config.getboolean('settings', 'enable_cleaner', fallback=False)
 settings__enable_history_sync = config.getboolean('settings', 'enable_history_sync', fallback=False)
 
-mqtt__host = config.get('mqtt', 'host', fallback='0.0.0.0')
-mqtt__port = config.getint('mqtt', 'port', fallback=1883)
-mqtt__keepalive = config.getint('mqtt', 'keepalive', fallback=60)
-mqtt__qos = config.getint('mqtt', 'qos', fallback=1)
-mqtt__retain = config.getboolean('mqtt', 'retain', fallback=False)
-mqtt__publish_value = config.getboolean('mqtt', 'publish_value', fallback=True)
-mqtt__attempt_reconnect_on_unavailable = config.getboolean('mqtt', 'attempt_reconnect_on_unavailable', fallback=True)
-mqtt__attempt_reconnect_secs = config.getint('mqtt', 'attempt_reconnect_secs', fallback=5)
-mqtt__debug = config.getboolean('mqtt', 'debug', fallback=False)
-
 influx_db__host = config.get('influx_db', 'host', fallback='0.0.0.0')
 influx_db__port = config.getint('influx_db', 'port', fallback=8086)
 influx_db__database = config.get('influx_db', 'database', fallback='db')


### PR DESCRIPTION
### Support multiple clients
Resolves #113 
- each client has own config
- config section creates client
    - config section title must follow `mqtt_X` where X can be anything
    - i.e. `settings`->`config.ini`: `[mqtt_local]` and `[mqtt_cloud]` will create 2 clients