### PR TITLE
allow null in model update

### DIFF
--- a/src/models/model_base.py
+++ b/src/models/model_base.py
@@ -37,7 +37,7 @@ class ModelBase(db.Model):
     # Issue #85 filter_by(...).update(...) is not working in inheritance
     def update(self, **kwargs):
         for key, value in kwargs.items():
-            if hasattr(self, key) and value is not None:
+            if hasattr(self, key):
                 setattr(self, key, value)
         self.check_self()
         db.session.commit()


### PR DESCRIPTION
previously the flask `RequestParser` auto filled all arguments to None if not present but they don't anymore so we can allow `None` in model attribute updates